### PR TITLE
show node labels in summary view

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "csv-parse": "^5.3.6",
     "date-fns": "^2.29.3",
     "debug": "^4.3.4",
+    "lodash": "^4.17.21",
     "lodash.debounce": "^4.0.8",
     "material-icons": "^1.13.2",
     "ohm-js": "^17.0.4",

--- a/src/views/index.tsx
+++ b/src/views/index.tsx
@@ -1,8 +1,9 @@
-import { createRefNode, useGraph, ValueNode } from "../graph"
+import { createRefNode, getLabelOfNode, useGraph, ValueNode } from "../graph"
 import { MapNodeView } from "./MapNodeView"
 import { TableNodeView } from "./TableNodeView"
 import classNames from "classnames"
 import { readAllProperties } from "../properties"
+import { mapValues } from "lodash"
 
 export interface NodeViewProps {
   node: ValueNode
@@ -111,11 +112,23 @@ export function SummaryView(props: NodeViewProps) {
   const { graph, changeGraph } = useGraph()
   const properties = readAllProperties(graph, props.node.id)
 
+  // If the property value is a node, resolve it to its label
+  const propertiesWithNodeValuesResolved = mapValues(properties, (property: string) => {
+    const regex = /^\s*#\[(?<id>[^\]]+)]\s*$/gm
+    const match = regex.exec(property)
+    if (!match?.groups?.id) {
+      return property
+    }
+    const nodeId = match.groups.id
+    const node = graph[nodeId]
+    return getLabelOfNode(node as ValueNode)
+  })
+
   return (
     <div className="text-sm italic flex gap-2">
       {Object.keys(properties).map((key) => (
         <p key={key}>
-          <span className="text-gray-400">{key}:</span> {properties[key]}
+          <span className="text-gray-400">{key}:</span> {propertiesWithNodeValuesResolved[key]}
         </p>
       ))}
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -718,13 +718,6 @@
   dependencies:
     "@types/lodash" "*"
 
-"@types/lodash.uniq@^4.5.7":
-  version "4.5.7"
-  resolved "https://registry.yarnpkg.com/@types/lodash.uniq/-/lodash.uniq-4.5.7.tgz#0773960ec0148b29e6a54821a65b878a0ebb5c1a"
-  integrity sha512-qg7DeAbdZMi6DGvCxThlJycykLLhETrJrQZ6F2KaZ+o0sNK1qRHz46lgNA+nHHjwrmA2a91DyiZTp3ey3m1rEw==
-  dependencies:
-    "@types/lodash" "*"
-
 "@types/lodash@*":
   version "4.14.191"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.191.tgz#09511e7f7cba275acd8b419ddac8da9a6a79e2fa"
@@ -1489,11 +1482,6 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
-
-lodash.uniq@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
-  integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
 
 lodash@^4, lodash@^4.17.21:
   version "4.17.21"


### PR DESCRIPTION
In summary view, if a property value just contains a node ID pointer, resolve it to its label

Before:

<img width="562" alt="CleanShot 2023-04-07 at 10 38 36@2x" src="https://user-images.githubusercontent.com/934016/230627255-89347125-2777-49ce-8cc9-6796f78885d8.png">

After:

<img width="466" alt="CleanShot 2023-04-07 at 10 38 30@2x" src="https://user-images.githubusercontent.com/934016/230627266-595efa59-0e0c-4ff2-bfe3-4ed39573508e.png">
